### PR TITLE
Fix duplicated navigation menu listeners

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -151,30 +151,34 @@ import Icon from "./Icon.astro";
 </style>
 
 <script>
+    let navigationToggle: HTMLButtonElement | null = null;
+    let navigation: HTMLElement | null = null;
+
+    const closeMenu = (event: Event) => {
+        if (navigation?.contains(event.target as Node)) return;
+        navigationToggle?.setAttribute("aria-expanded", "false");
+    };
+
+    const toggleMenu = (event: Event) => {
+        event.stopPropagation();
+        const navigationOpened = navigationToggle?.getAttribute(
+            "aria-expanded",
+        );
+        navigationToggle?.setAttribute(
+            "aria-expanded",
+            navigationOpened === "false" ? "true" : "false",
+        );
+    };
+
     function setupNavigation() {
-        const navigationToggle = document.querySelector(
+        navigationToggle = document.querySelector(
             '[aria-controls="primary-navigation"]',
         ) as HTMLButtonElement | null;
-        const navigation = document.querySelector(
+        navigation = document.querySelector(
             ".primary-navigation",
         ) as HTMLElement | null;
 
         if (!navigationToggle || !navigation) return;
-
-        const closeMenu = (event: Event) => {
-            if (navigation.contains(event.target as Node)) return;
-            navigationToggle.setAttribute("aria-expanded", "false");
-        };
-
-        const toggleMenu = (event: Event) => {
-            event.stopPropagation();
-            const navigationOpened =
-                navigationToggle.getAttribute("aria-expanded");
-            navigationToggle.setAttribute(
-                "aria-expanded",
-                navigationOpened === "false" ? "true" : "false",
-            );
-        };
 
         navigationToggle.removeEventListener("click", toggleMenu);
         document.removeEventListener("click", closeMenu);


### PR DESCRIPTION
## Summary
- prevent accumulation of menu toggle listeners in `Header.astro`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a367e0f9108322ae29be014f7a0dea